### PR TITLE
Сосание больше не вызывает маскарад виолейшн

### DIFF
--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -65,7 +65,9 @@
 		NPC.danger_source = null
 //		NPC.last_attacker = src
 
-	var/successes = secret_vampireroll(get_a_strength(user)+get_a_brawl(user), 6, user)
+	var/successes = secret_vampireroll(get_a_strength(user)+get_a_brawl(user), 6, user) SECONDS
+	if(isnpc(target))
+		successes = 6
 	target.Stun(successes*5)
 
 	if(target.bloodpool <= 1 && target.maxbloodpool > 1)

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -65,10 +65,10 @@
 		NPC.danger_source = null
 //		NPC.last_attacker = src
 
-	var/successes = secret_vampireroll(get_a_strength(user)+get_a_brawl(user), 6, user) SECONDS
+	var/successes = secret_vampireroll(get_a_strength(user)+get_a_brawl(user), 6, user) 
 	if(isnpc(target))
 		successes = 6
-	target.Stun(successes*5)
+	target.Stun(successes*5 SECONDS)
 
 	if(target.bloodpool <= 1 && target.maxbloodpool > 1)
 		to_chat(src, "<span class='warning'>You feel small amount of <b>BLOOD</b> in your victim.</span>")

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -68,7 +68,7 @@
 	var/successes = secret_vampireroll(get_a_strength(user)+get_a_brawl(user), 6, user) 
 	if(isnpc(target))
 		successes = 6
-	target.Stun(successes*5 SECONDS)
+	target.Stun(successes*5)
 
 	if(target.bloodpool <= 1 && target.maxbloodpool > 1)
 		to_chat(src, "<span class='warning'>You feel small amount of <b>BLOOD</b> in your victim.</span>")


### PR DESCRIPTION
## About The Pull Request

При сосании нпс тот получает гарантированный 3-х секундный стан, что по идеи должно убрать маскарад виолейшн.

## Why It's Good For The Game

Маскарад виолейшн из бэд

## Changelog
:cl:
add: Гарантированный стан на три секунды если сосать из нпс
/:cl: