### PR TITLE
Ауспекс должен видеть невидимок того же уровня

### DIFF
--- a/code/modules/vtmb/disciplines/auspex.dm
+++ b/code/modules/vtmb/disciplines/auspex.dm
@@ -13,7 +13,7 @@
 
 /datum/discipline_power/auspex/activate()
 	. = ..()
-	owner.see_invisible = SEE_INVISIBLE_LEVEL_OBFUSCATE+maxlevel
+	owner.see_invisible = SEE_INVISIBLE_LEVEL_OBFUSCATE+maxlevel+1
 
 /datum/discipline_power/auspex/deactivate()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Если все правильно работает то например, ауспекс 3 уровня будет видеть всех тех кто заюзал обфускейт 1-3 уровня.

## Why It's Good For The Game

Сейчас не так работает

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
add: Ауспекс должен видеть челов под обфускейтом того же уровня
/:cl: