### PR TITLE
Переработка фреймворка изучения дисциплин

### DIFF
--- a/code/modules/client/preferences_tabs/Char_settings and Charlist.dm
+++ b/code/modules/client/preferences_tabs/Char_settings and Charlist.dm
@@ -257,6 +257,8 @@
 				cost = 10
 			else if (clane.name == "Caitiff")
 				cost = discipline_level * 6
+			else if (discipline.learnable_by_clans.Find(clane.type))
+				cost = discipline_level * 6
 			else if (clane.clane_disciplines.Find(discipline_type))
 				cost = discipline_level * 5
 			else
@@ -270,44 +272,24 @@
 			dat += "-[discipline.desc]<BR>"
 			qdel(discipline)
 
-		if (clane.name == "Caitiff")
-			var/list/possible_new_disciplines = subtypesof(/datum/discipline) - discipline_types
-			for (var/discipline_type in possible_new_disciplines)
-				var/datum/discipline/discipline = new discipline_type
-				if (discipline.clan_restricted)
-					possible_new_disciplines -= discipline_type
-					qdel(discipline)
-				if (discipline.allowed_clans && discipline.allowed_clans.len)
-					if (!(clane.type in discipline.allowed_clans))
-						possible_new_disciplines -= discipline_type
-			if (possible_new_disciplines.len && (true_experience >= 10))
-				dat += "<a href='byond://?_src_=prefs;preference=newdiscipline;task=input'>Learn a new Discipline (10)</a><BR>"
+		var/list/possible_new_disciplines = subtypesof(/datum/discipline) - discipline_types - /datum/discipline/bloodheal
 
-		switch(clane.name)
+		for (var/discipline_type in possible_new_disciplines)
+			var/datum/discipline/discipline = new discipline_type
 
-			if("Salubri")
+			if (discipline.clan_restricted && !(discipline.learnable_by_clans.len))
+				possible_new_disciplines -= discipline_type
 
-				var/list/possible_new_valerens = list(/datum/discipline/valeren, /datum/discipline/valeren_warrior)
-				possible_new_valerens -= discipline_types
+			if (discipline.learnable_by_clans.len && !(clane.type in discipline.learnable_by_clans))
+				possible_new_disciplines -= discipline_type
 
-				if (possible_new_valerens.len && (true_experience >= 10))
-					dat += "<a href='byond://?_src_=prefs;preference=newvaleren;task=input'>Learn a new Valeren Path (10)</a><BR>"
+			if (!discipline.clan_restricted && !discipline.learnable_by_clans.len && clane.name != "Caitiff")
+				possible_new_disciplines -= discipline_type
 
-			if("Salubri Warrior")
+			qdel(discipline)
 
-				var/list/possible_new_valerens = list(/datum/discipline/valeren, /datum/discipline/valeren_warrior)
-				possible_new_valerens -= discipline_types
-
-				if (possible_new_valerens.len && (true_experience >= 10))
-					dat += "<a href='byond://?_src_=prefs;preference=newvaleren;task=input'>Learn a new Valeren Path (10)</a><BR>"
-
-			if("Baali")
-
-				var/list/possible_new_dt_paths = list(/datum/discipline/dt_path_taking_spirit, /datum/discipline/dt_path_fires_of_inferno, /datum/discipline/dt_path_pain)
-				possible_new_dt_paths -= discipline_types
-
-				if (possible_new_dt_paths.len && (true_experience >= 10))
-					dat += "<a href='byond://?_src_=prefs;preference=newdtpath;task=input'>Learn a new Dark Thaumaturgy Path (10)</a><BR>"
+		if (possible_new_disciplines.len && (true_experience >= 10))
+			dat += "<a href='byond://?_src_=prefs;preference=newdiscipline;task=input'>Learn a new Discipline (10)</a><BR>"
 
 	if(pref_species.name == "Ghoul")
 		for (var/i in 1 to discipline_types.len)

--- a/code/modules/vtmb/disciplines/_define.dm
+++ b/code/modules/vtmb/disciplines/_define.dm
@@ -209,7 +209,7 @@
 	///If this Discipline is unique to a certain Clan.
 	var/clan_restricted = FALSE
 	///If this Discipline is restricted to certain Clans.
-	var/list/allowed_clans = list()
+	var/list/learnable_by_clans = list()
 	///The root type of the powers this Discipline uses.
 	var/power_type = /datum/discipline_power
 	///If this Discipline can be selected at all, or has special handling.

--- a/code/modules/vtmb/disciplines/dt_path_fires_inferno.dm
+++ b/code/modules/vtmb/disciplines/dt_path_fires_inferno.dm
@@ -2,8 +2,8 @@
 	name = "Dark Thaumaturgy: The Fires of the Inferno"
 	desc = "This path of Dark Thaumaturgy allows the thaumaturge to control supernatural flames summoned from the depths of Hades."
 	icon_state = "thaumaturgy"
+	learnable_by_clans = list(/datum/vampireclane/baali)
 	power_type = /datum/discipline_power/dt_path_fires_of_inferno
-	allowed_clans = list(/datum/vampireclane/baali)
 
 /datum/discipline/dt_path_fires_of_inferno/post_gain()
 	. = ..()

--- a/code/modules/vtmb/disciplines/dt_path_pain.dm
+++ b/code/modules/vtmb/disciplines/dt_path_pain.dm
@@ -2,8 +2,8 @@
 	name = "Dark Thaumaturgy: Path of Pain"
 	desc = "This Path feeds on physical discomfort - with experience in its use, the Path of Pain can tear flesh from bones, crush bones, and rip internal organs with a single glance or word."
 	icon_state = "thaumaturgy"
+	learnable_by_clans = list(/datum/vampireclane/baali)
 	power_type = /datum/discipline_power/dt_path_pain
-	allowed_clans = list(/datum/vampireclane/baali)
 
 /datum/discipline/dt_path_pain/post_gain()
 	. = ..()

--- a/code/modules/vtmb/disciplines/dt_path_taking_spirit.dm
+++ b/code/modules/vtmb/disciplines/dt_path_taking_spirit.dm
@@ -2,8 +2,8 @@
 	name = "Dark Thaumaturgy: The Taking of the Spirit"
 	desc = "This path allows a vampire to drain his victims of Willpower, leaving them with a nearly soulless automaton willing to serve the Cainite without question."
 	icon_state = "thaumaturgy"
+	learnable_by_clans = list(/datum/vampireclane/baali)
 	power_type = /datum/discipline_power/dt_path_taking_spirit
-	allowed_clans = list(/datum/vampireclane/baali)
 
 /datum/discipline/dt_path_taking_spirit/post_gain()
 	. = ..()

--- a/code/modules/vtmb/disciplines/heal_valeren.dm
+++ b/code/modules/vtmb/disciplines/heal_valeren.dm
@@ -3,6 +3,7 @@
 	desc = "Use your third eye in healing or protecting needs."
 	icon_state = "healer"
 	clan_restricted = TRUE
+	learnable_by_clans = list(/datum/vampireclane/salubri, /datum/vampireclane/salubri_warrior)
 	power_type = /datum/discipline_power/valeren
 
 /datum/discipline_power/valeren

--- a/code/modules/vtmb/disciplines/warrior_valeren.dm
+++ b/code/modules/vtmb/disciplines/warrior_valeren.dm
@@ -3,6 +3,7 @@
 	desc = "Use your third eye in warding and delivering retribution."
 	icon_state = "valeren"
 	clan_restricted = TRUE
+	learnable_by_clans = list(/datum/vampireclane/salubri_warrior, /datum/vampireclane/salubri)
 	power_type = /datum/discipline_power/valeren_warrior
 
 

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -434,7 +434,7 @@
 						qdel(discipline)
 						continue
 
-				if (discipline.allowed_clans && discipline.allowed_clans.len)
+				if (discipline.learnable_by_clans && discipline.learnable_by_clans.len)
 					if (!can_access_discipline(src, type_to_create))
 						qdel(discipline)
 						continue
@@ -603,7 +603,7 @@
 				qdel(giving_discipline)
 				return
 
-		if (giving_discipline.allowed_clans && giving_discipline.allowed_clans.len)
+		if (giving_discipline.learnable_by_clans && giving_discipline.learnable_by_clans.len)
 			if(!can_access_discipline(student, teaching_discipline))
 				to_chat(teacher, span_warning("Your student is not whitelisted for any Clans which allows this Discipline, so they cannot learn it."))
 				qdel(giving_discipline)
@@ -692,12 +692,12 @@
 	//make sure it's actually restricted and this check is necessary
 	var/datum/discipline/discipline_object_checking = new discipline_checking
 
-	if (!discipline_object_checking.clan_restricted && (!discipline_object_checking.allowed_clans || !discipline_object_checking.allowed_clans.len))
+	if (!discipline_object_checking.clan_restricted && (!discipline_object_checking.learnable_by_clans || !discipline_object_checking.learnable_by_clans.len))
 		qdel(discipline_object_checking)
 		return TRUE
 
-	if (discipline_object_checking.allowed_clans && discipline_object_checking.allowed_clans.len)
-		for (var/allowed_clan in discipline_object_checking.allowed_clans)
+	if (discipline_object_checking.learnable_by_clans && discipline_object_checking.learnable_by_clans.len)
+		for (var/allowed_clan in discipline_object_checking.learnable_by_clans)
 			if (vampire_checking.clane.type == allowed_clan)
 				qdel(discipline_object_checking)
 				return TRUE

--- a/code/modules/vtmb/vampire_clane/baali.dm
+++ b/code/modules/vtmb/vampire_clane/baali.dm
@@ -7,7 +7,6 @@
 		/datum/discipline/presence,
 		/datum/discipline/daimonion
 	)
-	common_disciplines = list(/datum/discipline/dt_path_taking_spirit, /datum/discipline/dt_path_fires_of_inferno, /datum/discipline/dt_path_pain)
 	male_clothes = /obj/item/clothing/under/vampire/baali
 	female_clothes = /obj/item/clothing/under/vampire/baali/female
 	enlightenment = TRUE

--- a/code/modules/vtmb/vampire_clane/clane.dm
+++ b/code/modules/vtmb/vampire_clane/clane.dm
@@ -9,7 +9,6 @@ And it also helps for the character set panel
 	var/desc = "The clanless. The rabble. Of no importance."
 	var/list/clane_disciplines = list() //discipline datums
 	var/list/restricted_disciplines = list()
-	var/list/common_disciplines = list() //Discs that you don't start with but are easier to purchase like catiff instead of non clan discs
 	var/datum/outfit/clane_outfit
 	var/curse = "None."
 	var/list/allowed_jobs = list()

--- a/code/modules/vtmb/vampire_clane/salubri.dm
+++ b/code/modules/vtmb/vampire_clane/salubri.dm
@@ -7,7 +7,6 @@
 		/datum/discipline/fortitude,
 		/datum/discipline/valeren
 	)
-	common_disciplines = list(/datum/discipline/valeren_warrior)
 	male_clothes = /obj/item/clothing/under/vampire/salubri
 	female_clothes = /obj/item/clothing/under/vampire/salubri/female
 	enlightenment = FALSE

--- a/code/modules/vtmb/vampire_clane/salubri_warrior.dm
+++ b/code/modules/vtmb/vampire_clane/salubri_warrior.dm
@@ -7,7 +7,6 @@
 		/datum/discipline/fortitude,
 		/datum/discipline/valeren_warrior
 	)
-	common_disciplines = list(/datum/discipline/valeren)
 	male_clothes = /obj/item/clothing/under/vampire/salubri
 	female_clothes = /obj/item/clothing/under/vampire/salubri/female
 	whitelisted = TRUE


### PR DESCRIPTION
## About The Pull Request

Если в кратце - если у дисциплины задана переменная learnable_by_clans и в этой переменной есть лист с определенными кланами, например баали или салюбри, то обладатели данных кланов смогут изучить данную дисциплину.

Бонусом я пофиксил баг с катиффами которые не могли изучить три дисциплины на старте. А так-же я сделал так чтобы вместо типа дисциплин т.е. /datum/discipline/potence например, просто отображалось бы Potence.

Хуйнушку я потестил так что багов не должно быть, все компилится и те кто не должен не могут изучить дисцы для них не предназначенные

## Why It's Good For The Game

Чтобы сто раз не создавать одно и тоже я сделал так чтобы можно сто раз использовать одну и ту же хуйню

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
fix: Каитиффы снова могут изучить 3 дисцы на старте
fix: Список дисц отображает имя а не датум
add: Фреймворчик для дисциплин в дальнейшнем
/:cl: