### PR TITLE
Фикс экрана лобби

### DIFF
--- a/code/modules/mob/dead/new_player/lobby_screen.dm
+++ b/code/modules/mob/dead/new_player/lobby_screen.dm
@@ -19,6 +19,7 @@ GLOBAL_DATUM_INIT(lobby_screen, /datum/lobby_screen, new)
 
 /datum/lobby_screen/proc/hide(client/user)
 	if(user.mob)
+		user.mob << browse(null, "window=lobbybrowser")
 		winset(user, "lobbybrowser", "is-disabled=true;is-visible=false")
 
 /datum/lobby_screen/proc/update_to_all()


### PR DESCRIPTION
## About The Pull Request

Теперь после закрытия экрана ресурсы высвобождаются, чтобы не влиять на игровой процесс

## Why It's Good For The Game

Возможно, меньше затрат ресурсов на отрисовку несуществующего экрана

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog


:cl: FeudeyTF
fix: Освобождение ресурсов экрана лобби после захода в игру
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
