### PR TITLE
Фикс проблем с отображением иконки говорения персонажа

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -210,6 +210,10 @@
 	///For storing what do_after's someone has, key = string, value = amount of interactions of that type happening.
 	var/list/do_afters
 
+	var/active_typing_indicator
+
+	var/active_thinking_indicator
+
 	///Allows a datum to intercept all click calls this mob is the source of
 	var/datum/click_intercept
 

--- a/code/modules/tgui_input/say_modal/typing.dm
+++ b/code/modules/tgui_input/say_modal/typing.dm
@@ -94,25 +94,28 @@
 
 /// Overrides for overlay creation
 /mob/living/carbon/create_thinking_indicator()
-	if(stat != CONSCIOUS || !HAS_TRAIT(src, TRAIT_THINKING_IN_CHARACTER))
+	if(active_thinking_indicator || active_typing_indicator || stat != CONSCIOUS || !HAS_TRAIT(src, TRAIT_THINKING_IN_CHARACTER))
 		return FALSE
-
-	var/mutable_appearance/say_overlay = mutable_appearance('icons/mob/talk.dmi', "default0", -SAY_LAYER)
-	overlays_standing[SAY_LAYER] = say_overlay
-	apply_overlay(SAY_LAYER)
+	active_thinking_indicator = mutable_appearance('icons/mob/talk.dmi', "default0", SAY_LAYER)
+	add_overlay(active_thinking_indicator)
 
 /mob/living/carbon/remove_thinking_indicator()
-	remove_overlay(SAY_LAYER)
+	if(!active_thinking_indicator)
+		return FALSE
+	cut_overlay(active_thinking_indicator)
+	active_thinking_indicator = null
 
 /mob/living/carbon/create_typing_indicator()
-	if(stat != CONSCIOUS || !HAS_TRAIT(src, TRAIT_THINKING_IN_CHARACTER))
+	if(active_typing_indicator || active_thinking_indicator ||stat != CONSCIOUS || !HAS_TRAIT(src, TRAIT_THINKING_IN_CHARACTER))
 		return FALSE
-	var/mutable_appearance/say_overlay = mutable_appearance('icons/mob/talk.dmi', "default0", -SAY_LAYER)
-	overlays_standing[SAY_LAYER] = say_overlay
-	apply_overlay(SAY_LAYER)
+	active_typing_indicator = mutable_appearance('icons/mob/talk.dmi', "default0", SAY_LAYER)
+	add_overlay(active_typing_indicator)
 
 /mob/living/carbon/remove_typing_indicator()
-	remove_overlay(SAY_LAYER)
+	if(!active_typing_indicator)
+		return FALSE
+	cut_overlay(active_typing_indicator)
+	active_typing_indicator = null
 
 /mob/living/carbon/remove_all_indicators()
 	REMOVE_TRAIT(src, TRAIT_THINKING_IN_CHARACTER, CURRENTLY_TYPING_TRAIT)

--- a/code/modules/vtmb/disciplines/melpominee.dm
+++ b/code/modules/vtmb/disciplines/melpominee.dm
@@ -55,7 +55,7 @@
 		if (!victim.is_face_visible())
 			masked = TRUE
 			base_difficulty += 2
-		if (victim.overlays_standing[SAY_LAYER]) //ugly way to check for if the victim is currently typing
+		if (victim.active_typing_indicator)
 			base_difficulty += 2
 
 	for (var/mob/living/hearer in (oviewers(7, target) - owner))

--- a/code/modules/wod13/npc.dm
+++ b/code/modules/wod13/npc.dm
@@ -372,13 +372,11 @@
 	is_talking = TRUE
 	var/delay = round(length_char(message)/2)
 	spawn(5)
-		remove_overlay(SAY_LAYER)
-		var/mutable_appearance/say_overlay = mutable_appearance('icons/mob/talk.dmi', "default0", -SAY_LAYER)
-		overlays_standing[SAY_LAYER] = say_overlay
-		apply_overlay(SAY_LAYER)
+		ADD_TRAIT(src, TRAIT_THINKING_IN_CHARACTER, CURRENTLY_TYPING_TRAIT)
+		create_typing_indicator()
 		spawn(max(1, delay))
 			if(stat != DEAD)
-				remove_overlay(SAY_LAYER)
+				remove_all_indicators()
 				say(message)
 				is_talking = FALSE
 

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -3,7 +3,7 @@
 ## administration, and the in game library.
 
 ## Should SQL be enabled? Uncomment to enable
-SQL_ENABLED
+## SQL_ENABLED
 
 ## Should the whitelist database be enabled? Uncomment to enable
 WHITELISTS_ENABLED

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -3,7 +3,7 @@
 ## administration, and the in game library.
 
 ## Should SQL be enabled? Uncomment to enable
-## SQL_ENABLED
+SQL_ENABLED
 
 ## Should the whitelist database be enabled? Uncomment to enable
 WHITELISTS_ENABLED


### PR DESCRIPTION
## About The Pull Request

Фикс проблем с отображением иконки говорения персонажа. Иногда она не пропадала и оставалась навсегда у игрока.
Также исправил некоторые места, где использовались грубые решения

## Why It's Good For The Game

Это фикс

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog


:cl: FeudeyTF
fix: Исправил отображение иконки говорения игрока
/:cl:
